### PR TITLE
feat: VM Modal 상태 캐싱 및 비동기 데이터 처리 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7061,19 +7061,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",


### PR DESCRIPTION
- 전역 Map 객체 도입, vm상태 정보 메모리에 저장,  SWR 패턴 따르도록 함.
- 사용자가 빠르게 다른 인스턴스 클릭해도 이전 인스턴스 비동기 응답이 화면 덮어쓰지 않도록 함.
- 사용자가 인터렉션 중일 때에는 서버 데이터로 덮어쓰지 않도록 함.